### PR TITLE
Embed the license to file to make drop-in easier

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -1,6 +1,28 @@
 " Author: Prabir Shrestha <mail at prabir dot me>
-" License: The MIT License
 " Website: https://github.com/prabirshrestha/async.vim
+" License: The MIT License {{{
+"   The MIT License (MIT)
+"
+"   Copyright (c) 2016 Prabir Shrestha
+"
+"   Permission is hereby granted, free of charge, to any person obtaining a copy
+"   of this software and associated documentation files (the "Software"), to deal
+"   in the Software without restriction, including without limitation the rights
+"   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+"   copies of the Software, and to permit persons to whom the Software is
+"   furnished to do so, subject to the following conditions:
+"
+"   The above copyright notice and this permission notice shall be included in all
+"   copies or substantial portions of the Software.
+"
+"   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+"   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+"   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+"   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+"   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+"   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+"   SOFTWARE.
+" }}}
 
 let s:save_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
This library is distributed with MIT license. It requires to show the copyright notice in software. So when embedding this library in a plugin, a user also needs to show the copyright in the plugin.

By embedding a license description and copyright notice to source file, a user doesn't need to take care about license notice because it is already put in the source file.