### PR TITLE
Fix that async#job#wait() always returns 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ endfunction
 
 function! yourplugin#job#wait(jobids, ...) abort
     let l:timeout = get(a:000, 0, -1)
-    call s:job_wait(a:jobids, l:timeout)
+    return s:job_wait(a:jobids, l:timeout)
 endfunction
 " }}}
 ```

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -260,6 +260,6 @@ endfunction
 
 function! async#job#wait(jobids, ...) abort
     let l:timeout = get(a:000, 0, -1)
-    call s:job_wait(a:jobids, l:timeout)
+    return s:job_wait(a:jobids, l:timeout)
 endfunction
 " }}}


### PR DESCRIPTION
Use 'return' instead of 'call' to fix it.

Sorry, it was my mistake in #12.