### PR TITLE
default to noblock if supported by vim 8 to avoid deadlocks causing vim to hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ endfunction
 " }}}
 ```
 
+## Known Issues
+
+* Vim 8 hangs when sending large strings
+This only happens for Vim 8 and not NeoVim. Please update your vim to 8.1.350.
+Refer to https://github.com/vim/vim/issues/2548 for more details.
+
 ## Todos
 * Fallback to sync `system()` calls in vim that doesn't support `job`
 * `job_stop` and `job_send` is treated as noop when using `system()`

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -142,12 +142,16 @@ function! s:job_start(cmd, opts) abort
     elseif l:jobtype == s:job_type_vimjob
         let s:jobidseq = s:jobidseq + 1
         let l:jobid = s:jobidseq
-        let l:job  = job_start(a:cmd, {
+        let l:jobopt = {
             \ 'out_cb': function('s:out_cb', [l:jobid, a:opts]),
             \ 'err_cb': function('s:err_cb', [l:jobid, a:opts]),
             \ 'exit_cb': function('s:exit_cb', [l:jobid, a:opts]),
             \ 'mode': 'raw',
-        \})
+        \ }
+        if has('patch-8.1.350')
+          let l:jobopt['noblock'] = 1
+        endif
+        let l:job  = job_start(a:cmd, l:jobopt)
         if job_status(l:job) !=? 'run'
             return -1
         endif


### PR DESCRIPTION
Refer to https://github.com/vim/vim/issues/2548 for more details.

I'm defaulting to `noblock` to true if it supports which could be a breaking change. Please give it a try. Will be merging in few days.