### PR TITLE
Fix variable name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ else
 endif
 
 " If you want to wait the job:
-call async#job#wait([job], 5000)  " timeout: 5 sec
+call async#job#wait([jobid], 5000)  " timeout: 5 sec
 
 " If you want to stop the job:
-call async#job#stop(job)
+call async#job#stop(jobid)
 ```
 
 ## APIs


### PR DESCRIPTION
We create a job and assign the id to jobid, but then use job as if it
were the id. Fix to use same variable.

I didn't test the code, but this looks more right.