### PR TITLE
Fix to work with versions of vim older than 8.0.1127

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -200,7 +200,7 @@ function! s:flush_vim_sendraw(jobid, timer) abort
         let l:to_send = l:jobinfo.buffer[:1023]
         let l:jobinfo.buffer = l:jobinfo.buffer[1024:]
         call ch_sendraw(l:jobinfo.channel, l:to_send)
-        call timer_start(0, function('s:flush_vim_sendraw', [a:jobid]))
+        call timer_start(1, function('s:flush_vim_sendraw', [a:jobid]))
     endif
 endfunction
 


### PR DESCRIPTION
`timer_start(0, ...)` does not work with old vim on 32-bit systems. This PR replaces it with `timer_start(1, ...)`.

https://github.com/vim/vim/pull/2116