### PR TITLE
Add "sleep 1m" to read blocked channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 script:
-    - pip install --user --upgrade vim-vint
+    - pip install --user --upgrade vim-vint pathlib enum34
     - python --version
     - vim --version
     - vint --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 script:
-    - pip install --user --upgrade vim-vint pathlib enum34
+    - pip install --user --upgrade vim-vint pathlib enum34 typing
     - python --version
     - vim --version
     - vint --version

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -193,15 +193,17 @@ function! s:flush_vim_sendraw(jobid, timer) abort
     " https://github.com/vim/vim/issues/2548
     " https://github.com/natebosch/vim-lsc/issues/67#issuecomment-357469091
     let l:jobinfo = s:jobs[a:jobid]
-    if len(l:jobinfo.buffer) <= 1024
-        call ch_sendraw(l:jobinfo.channel, l:jobinfo.buffer)
-        let l:jobinfo.buffer = ''
-    else
+    while 1
+        sleep 1m
+        if len(l:jobinfo.buffer) <= 1024
+            call ch_sendraw(l:jobinfo.channel, l:jobinfo.buffer)
+            let l:jobinfo.buffer = ''
+            break
+        endif
         let l:to_send = l:jobinfo.buffer[:1023]
         let l:jobinfo.buffer = l:jobinfo.buffer[1024:]
         call ch_sendraw(l:jobinfo.channel, l:to_send)
-        call timer_start(1, function('s:flush_vim_sendraw', [a:jobid]))
-    endif
+    endwhile
 endfunction
 
 function! s:job_wait_single(jobid, timeout, start) abort

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -195,6 +195,10 @@ function! s:flush_vim_sendraw(jobid, timer) abort
     let l:jobinfo = s:jobs[a:jobid]
     while 1
         sleep 1m
+        if ch_canread(l:jobinfo.channel)
+            call timer_start(1, function('s:flush_vim_sendraw', [a:jobid]))
+            return
+        endif
         if len(l:jobinfo.buffer) <= 1024
             call ch_sendraw(l:jobinfo.channel, l:jobinfo.buffer)
             let l:jobinfo.buffer = ''


### PR DESCRIPTION
See https://github.com/prabirshrestha/vim-lsp/issues/235

Vim does not read datas from channel while status is not idle. Also event of timer will not triggered. This change add "sleep 1m" to make idle status to read blocked channel.