### PR TITLE
Fix invalid behavior on Neovim

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -93,6 +93,9 @@ function! s:on_exit(jobid, status, event) abort
         if has_key(l:jobinfo.opts, 'on_exit')
             call l:jobinfo.opts.on_exit(a:jobid, a:status, a:event)
         endif
+        if has_key(s:jobs, a:jobid)
+            call remove(s:jobs, a:jobid)
+        endif
     endif
 endfunction
 
@@ -183,9 +186,6 @@ function! s:job_stop(jobid) abort
             endtry
         elseif l:jobinfo.type == s:job_type_vimjob
             call job_stop(s:jobs[a:jobid].job)
-        endif
-        if has_key(s:jobs, a:jobid)
-            call remove(s:jobs, a:jobid)
         endif
     endif
 endfunction

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -173,7 +173,14 @@ function! s:job_stop(jobid) abort
     if has_key(s:jobs, a:jobid)
         let l:jobinfo = s:jobs[a:jobid]
         if l:jobinfo.type == s:job_type_nvimjob
-            call jobstop(a:jobid)
+            " See: vital-Whisky/System.Job
+            try
+              call jobstop(a:jobid)
+            catch /^Vim\%((\a\+)\)\=:E900/
+              " NOTE:
+              " Vim does not raise exception even the job has already closed so fail
+              " silently for 'E900: Invalid job id' exception
+            endtry
         elseif l:jobinfo.type == s:job_type_vimjob
             call job_stop(s:jobs[a:jobid].job)
         endif

--- a/test/async.vimspec
+++ b/test/async.vimspec
@@ -4,6 +4,11 @@ function! s:on_stdout(ctx, id, data, event) abort
 endfunction
 
 Describe async
+  Before
+    let scope = themis#helper('scope')
+    let vars = scope.vars('autoload/async/job.vim')
+  End
+
   Describe async#job#start
     It can start cmmand and return numbered job-id
       let job = async#job#start('vim --version', {})
@@ -23,6 +28,27 @@ Describe async
       sleep 1
       call async#job#stop(job)
       Assert !filereadable('i-love-vim')
+    End
+
+    It invokes 'on_exit' callback
+      let ns = { 'called': 0 }
+      let job = async#job#start('bash -c "sleep 2 && touch i-love-vim"', {
+            \ 'on_exit': { -> extend(ns, { 'called': 1 }) },
+            \})
+      call async#job#stop(job)
+      sleep 1m
+      Assert Equals(ns, {'called': 1})
+    End
+
+    It removes a corresponding job from an internal variable
+      let job1 = async#job#start('bash -c "sleep 2 && touch i-love-vim"', {})
+      let job2 = async#job#start('bash -c "sleep 2 && touch i-love-vim"', {})
+      Assert Equals(sort(keys(vars.jobs)), sort([string(job1), string(job2)]))
+      call async#job#stop(job1)
+      sleep 1m
+      Assert Equals(sort(keys(vars.jobs)), sort([string(job2)]))
+      sleep 3
+      Assert Equals(sort(keys(vars.jobs)), [])
     End
   End
 


### PR DESCRIPTION
This PR fixed the following two invalid behaviors in Neovim

- Vim does not raise E900 on invalid jobid but Neovim thus test fails on Neovim
- The timing of exit callback is a bit different between Vim and Neovim

fyi, use the following command to execute tests on Neovim

```
$ THEMIS_VIM=nvim THEMIS_ARGS="-e -s --headless" themis
```