### PR TITLE
Add support for sending data and closing stdin at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ function! yourplugin#job#stop(jobid) abort
     call s:job_stop(a:jobid)
 endfunction
 
-function! yourplugin#job#send(jobid, data, opts) abort
-    call s:job_send(a:jobid, a:data, a:opts)
+function! yourplugin#job#send(jobid, data) abort
+    call s:job_send(a:jobid, a:data)
 endfunction
 
 function! yourplugin#job#wait(jobids, ...) abort

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ function! yourplugin#job#stop(jobid) abort
     call s:job_stop(a:jobid)
 endfunction
 
-function! yourplugin#job#send(jobid, data) abort
-    call s:job_send(a:jobid, a:data)
+function! yourplugin#job#send(jobid, data, opts) abort
+    call s:job_send(a:jobid, a:data, a:opts)
 endfunction
 
 function! yourplugin#job#wait(jobids, ...) abort

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -198,7 +198,15 @@ function! s:job_send(jobid, data, close_stdin) abort
           call chanclose(a:jobid, 'stdin')
         endif
     elseif l:jobinfo.type == s:job_type_vimjob
-        if has('patch-8.1.0818')
+        " There is no easy way to know when ch_sendraw() finishes writing data
+        " on a non-blocking channels -- has('patch-8.1.889') -- and because of
+        " this, we cannot safely call ch_close_in().  So when we find ourselves
+        " in this situation (i.e. noblock=1 and close stdin after send) we fall
+        " back to using s:flush_vim_sendraw() and wait for transmit buffer to be
+        " empty
+        "
+        " XXX https://groups.google.com/d/topic/vim_dev/UNNulkqb60k/discussion
+        if has('patch-8.1.818') && (!has('patch-8.1.889') || !a:close_stdin)
             call ch_sendraw(l:jobinfo.channel, a:data)
         else
             let l:jobinfo.buffer .= a:data

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -205,7 +205,10 @@ function! s:job_send(jobid, data, close_stdin) abort
             call s:flush_vim_sendraw(a:jobid, v:null)
         endif
         if a:close_stdin
-          call ch_close_in(l:jobinfo.channel)
+            while len(l:jobinfo.buffer) != 0
+                sleep 1m
+            endwhile
+            call ch_close_in(l:jobinfo.channel)
         endif
     endif
 endfunction

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -190,11 +190,12 @@ function! s:job_stop(jobid) abort
     endif
 endfunction
 
-function! s:job_send(jobid, data, close_stdin) abort
+function! s:job_send(jobid, data, opts) abort
     let l:jobinfo = s:jobs[a:jobid]
+    let l:close_stdin = get(a:opts, 'close_stdin')
     if l:jobinfo.type == s:job_type_nvimjob
         call jobsend(a:jobid, a:data)
-        if a:close_stdin
+        if l:close_stdin
           call chanclose(a:jobid, 'stdin')
         endif
     elseif l:jobinfo.type == s:job_type_vimjob
@@ -205,14 +206,14 @@ function! s:job_send(jobid, data, close_stdin) abort
         " back to using s:flush_vim_sendraw() and wait for transmit buffer to be
         " empty
         "
-        " XXX https://groups.google.com/d/topic/vim_dev/UNNulkqb60k/discussion
-        if has('patch-8.1.818') && (!has('patch-8.1.889') || !a:close_stdin)
+        " Ref: https://groups.google.com/d/topic/vim_dev/UNNulkqb60k/discussion
+        if has('patch-8.1.818') && (!has('patch-8.1.889') || !l:close_stdin)
             call ch_sendraw(l:jobinfo.channel, a:data)
         else
             let l:jobinfo.buffer .= a:data
             call s:flush_vim_sendraw(a:jobid, v:null)
         endif
-        if a:close_stdin
+        if l:close_stdin
             while len(l:jobinfo.buffer) != 0
                 sleep 1m
             endwhile
@@ -304,9 +305,8 @@ function! async#job#stop(jobid) abort
     call s:job_stop(a:jobid)
 endfunction
 
-function! async#job#send(jobid, data, ...) abort
-    let l:close_stdin = get(a:000, 0, 0)
-    call s:job_send(a:jobid, a:data, l:close_stdin)
+function! async#job#send(jobid, data, opts) abort
+    call s:job_send(a:jobid, a:data, a:opts)
 endfunction
 
 function! async#job#wait(jobids, ...) abort

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -192,7 +192,7 @@ endfunction
 
 function! s:job_send(jobid, data, opts) abort
     let l:jobinfo = s:jobs[a:jobid]
-    let l:close_stdin = get(a:opts, 'close_stdin')
+    let l:close_stdin = get(a:opts, 'close_stdin', 0)
     if l:jobinfo.type == s:job_type_nvimjob
         call jobsend(a:jobid, a:data)
         if l:close_stdin

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -305,8 +305,9 @@ function! async#job#stop(jobid) abort
     call s:job_stop(a:jobid)
 endfunction
 
-function! async#job#send(jobid, data, opts) abort
-    call s:job_send(a:jobid, a:data, a:opts)
+function! async#job#send(jobid, data, ...) abort
+    let l:opts = get(a:000, 0, {})
+    call s:job_send(a:jobid, a:data, l:opts)
 endfunction
 
 function! async#job#wait(jobids, ...) abort


### PR DESCRIPTION
An additional optional parameter was added to `async#job#send` that user
can use (i.e. passing in a truthy value) to close stdin right after data
transfer.