### PR TITLE
Fix not restoring cpoptions

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -307,3 +307,6 @@ function! async#job#pid(jobid) abort
     return s:job_pid(a:jobid)
 endfunction
 " }}}
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
In the autoload file you save and reset &cpo, but forget to restore them at the end.