### PR TITLE
Add async#job#connect

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -192,7 +192,11 @@ function! s:job_stop(jobid) abort
               " silently for 'E900: Invalid job id' exception
             endtry
         elseif l:jobinfo.type == s:job_type_vimjob
-            call job_stop(s:jobs[a:jobid].job)
+            if type(s:jobs[a:jobid].job) == v:t_job
+                call job_stop(s:jobs[a:jobid].job)
+            elseif type(s:jobs[a:jobid].job) == v:t_channel
+                call ch_close(s:jobs[a:jobid].job)
+            endif
         endif
     endif
 endfunction
@@ -344,12 +348,19 @@ endfunction
 function! async#job#connect(addr, opts) abort
     let s:jobidseq = s:jobidseq + 1
     let l:jobid = s:jobidseq
-    let l:ch = ch_open(a:addr, {})
-    call ch_setoptions(l:ch, {
-        \ 'callback': function('s:callback_cb', [l:jobid, a:opts]),
-        \ 'close_cb': function('s:close_cb', [l:jobid, a:opts]),
-        \ 'mode': 'raw',
-    \})
+    let l:retry = 0
+    while l:retry < 5
+        let l:ch = ch_open(a:addr, {})
+        call ch_setoptions(l:ch, {
+            \ 'callback': function('s:callback_cb', [l:jobid, a:opts]),
+            \ 'close_cb': function('s:close_cb', [l:jobid, a:opts]),
+            \ 'mode': 'raw',
+        \})
+        if ch_status(l:ch) ==# 'open'
+            break
+        endif
+        sleep 1m
+    endwhile
     let s:jobs[l:jobid] = {
         \ 'type': s:job_type_vimjob,
         \ 'opts': a:opts,

--- a/test/async.vimspec
+++ b/test/async.vimspec
@@ -76,6 +76,9 @@ Describe async
 
   Describe async#job#connect
     It can connect tcp-server and return numbered job-id
+      if has('nvim')
+        Skip nvim is not supported
+      endif
       let ctx = { 'output': [] }
       let job = async#job#connect('github.com:80', {'on_stdout': function('s:on_stdout', [ctx])})
       Assert Equals(type(job), v:t_number)

--- a/test/async.vimspec
+++ b/test/async.vimspec
@@ -73,4 +73,18 @@ Describe async
       Assert Equals(out, 'i-love-vim')
     End
   End
+
+  Describe async#job#connect
+    It can connect tcp-server and return numbered job-id
+      let ctx = { 'output': [] }
+      let job = async#job#connect('github.com:80', {'on_stdout': function('s:on_stdout', [ctx])})
+      Assert Equals(type(job), v:t_number)
+      call async#job#send(job, "GET / HTTP/1.0\r\n\r\n")
+      sleep 4
+      let out = join(ctx.output, '')
+      let firstline = trim(split(out, '[\r\n]')[0])
+      Assert Equals(firstline, 'HTTP/1.1 301 Moved Permanently')
+    End
+  End
+
 End


### PR DESCRIPTION
Now I could implement tcp feature on vim-lsp with async.vim. I'll send another pull-request to enable this.

```vim
augroup vim_lsp_settings_godot
  au!
  LspRegisterServer {
      \ 'name': 'godot',
      \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6008')},
      \ 'root_uri':{server_info->lsp_settings#get('godot', 'root_uri', lsp_settings#root_uri('godot'))},
      \ 'initialization_options': lsp_settings#get('godot', 'initialization_options', v:null),
      \ 'allowlist': lsp_settings#get('godot', 'allowlist', ['gdscript3', 'gdscript']),
      \ 'blocklist': lsp_settings#get('godot', 'blocklist', []),
      \ 'config': lsp_settings#get('godot', 'config', lsp_settings#server_config('godot')),
      \ 'workspace_config': lsp_settings#get('godot', 'workspace_config', {}),
      \ 'semantic_highlight': lsp_settings#get('godot', 'semantic_highlight', {}),
      \ }
augroup END
```

https://github.com/prabirshrestha/vim-lsp/issues/469
https://github.com/prabirshrestha/vim-lsp/pull/928
https://github.com/mattn/vim-lsp-settings/issues/338
