### PR TITLE
avoid has_key check for on_stdout and on_stderr

### DIFF
--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -33,6 +33,9 @@ let s:job_type_nvimjob = 'nvimjob'
 let s:job_type_vimjob = 'vimjob'
 let s:job_error_unsupported_job_type = -2 " unsupported job type
 
+function! s:noop(...) abort
+endfunction
+
 function! s:job_supported_types() abort
     let l:supported_types = []
     if has('nvim')
@@ -49,15 +52,11 @@ function! s:job_supports_type(type) abort
 endfunction
 
 function! s:out_cb(jobid, opts, job, data) abort
-    if has_key(a:opts, 'on_stdout')
-        call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
-    endif
+    call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
 endfunction
 
 function! s:err_cb(jobid, opts, job, data) abort
-    if has_key(a:opts, 'on_stderr')
-        call a:opts.on_stderr(a:jobid, split(a:data, "\n", 1), 'stderr')
-    endif
+    call a:opts.on_stderr(a:jobid, split(a:data, "\n", 1), 'stderr')
 endfunction
 
 function! s:exit_cb(jobid, opts, job, status) abort
@@ -70,21 +69,13 @@ function! s:exit_cb(jobid, opts, job, status) abort
 endfunction
 
 function! s:on_stdout(jobid, data, event) abort
-    if has_key(s:jobs, a:jobid)
-        let l:jobinfo = s:jobs[a:jobid]
-        if has_key(l:jobinfo.opts, 'on_stdout')
-            call l:jobinfo.opts.on_stdout(a:jobid, a:data, a:event)
-        endif
-    endif
+    let l:jobinfo = s:jobs[a:jobid]
+    call l:jobinfo.opts.on_stdout(a:jobid, a:data, a:event)
 endfunction
 
 function! s:on_stderr(jobid, data, event) abort
-    if has_key(s:jobs, a:jobid)
-        let l:jobinfo = s:jobs[a:jobid]
-        if has_key(l:jobinfo.opts, 'on_stderr')
-            call l:jobinfo.opts.on_stderr(a:jobid, a:data, a:event)
-        endif
-    endif
+    let l:jobinfo = s:jobs[a:jobid]
+    call l:jobinfo.opts.on_stderr(a:jobid, a:data, a:event)
 endfunction
 
 function! s:on_exit(jobid, status, event) abort
@@ -135,8 +126,8 @@ function! s:job_start(cmd, opts) abort
 
     if l:jobtype == s:job_type_nvimjob
         call extend(l:jobopt, {
-            \ 'on_stdout': function('s:on_stdout'),
-            \ 'on_stderr': function('s:on_stderr'),
+            \ 'on_stdout': has_key(a:opts, 'on_stdout') ? function('s:on_stdout') : function('s:noop'),
+            \ 'on_stderr': has_key(a:opts, 'on_stderr') ? function('s:on_stderr') : function('s:noop'),
             \ 'on_exit': function('s:on_exit'),
         \})
         let l:job = jobstart(a:cmd, l:jobopt)
@@ -153,8 +144,8 @@ function! s:job_start(cmd, opts) abort
         let s:jobidseq = s:jobidseq + 1
         let l:jobid = s:jobidseq
         call extend(l:jobopt, {
-            \ 'out_cb': function('s:out_cb', [l:jobid, a:opts]),
-            \ 'err_cb': function('s:err_cb', [l:jobid, a:opts]),
+            \ 'out_cb': has_key(a:opts, 'on_stdout') ? function('s:out_cb', [l:jobid, a:opts]) : function('s:noop'),
+            \ 'err_cb': has_key(a:opts, 'on_stderr') ? function('s:err_cb', [l:jobid, a:opts]) : function('s:noop'),
             \ 'exit_cb': function('s:exit_cb', [l:jobid, a:opts]),
             \ 'mode': 'raw',
         \ })


### PR DESCRIPTION
`has_key` call requires hashing and dict lookup which can be very expensive when it we get lot of messages. Avoid the call by adding noop function instead.

before:
```vim
FUNCTION  <SNR>177_out_cb()
    Defined: ~/.config/nvim/plugins/vim-lsp/autoload/lsp/utils/job.vim:54
Called 9 times
Total time:   0.098468
 Self time:   0.000505

count  total (s)   self (s)
    9              0.000159     if has_key(a:opts, 'on_stdout')
    9   0.098267   0.000304         call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
    9              0.000013     endif

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    9   0.098468   0.000505  <SNR>177_out_cb()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
    9   0.098468   0.000505  <SNR>177_out_cb()
```

after:
```vim
FUNCTION  <SNR>177_out_cb()
    Defined: ~/.config/nvim/plugins/vim-lsp/autoload/lsp/utils/job.vim:57
Called 9 times
Total time:   0.083334
 Self time:   0.000356

count  total (s)   self (s)
    9   0.083314   0.000336     call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    9   0.083334   0.000356  <SNR>177_out_cb()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
    9   0.083334   0.000356  <SNR>177_out_cb()
```