### PR TITLE
add support for choosing between array/string/raw for the stderr or stdout data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ let jobid = async#job#start(argv, {
     \ 'on_stdout': function('s:handler'),
     \ 'on_stderr': function('s:handler'),
     \ 'on_exit': function('s:handler'),
+    \ 'normalize': 'array'
 \ })
 
 if jobid > 0
@@ -47,6 +48,18 @@ APIs are based on neovim's job control APIs.
 * [jobstop()](https://neovim.io/doc/user/eval.html#jobstop%28%29)
 * [jobwait()](https://neovim.io/doc/user/eval.html#jobwait%28%29)
 * [jobpid()](https://neovim.io/doc/user/eval.html#jobpid%28%29)
+
+### Normalizing data
+
+By default `stdout` and `stderr` data is an array. This is a noop for neovim
+but requiring using `split` in vim. This can tend to be costly if you are want
+a string since you are joining the splited string. To avoid this unncessary
+conversion you can normalize it to `string` so it is a noop in vim but a `join`
+for neovim. If you prefer to disable normalization pass normalization as `raw`.
+
+```
+normalize: 'array' " Valid values are 'array', 'string' or 'raw'
+```
 
 ## Embedding
 

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -52,10 +52,18 @@ function! s:job_supports_type(type) abort
 endfunction
 
 function! s:out_cb(jobid, opts, job, data) abort
+    call a:opts.on_stdout(a:jobid, a:data, 'stdout')
+endfunction
+
+function! s:out_cb_array(jobid, opts, job, data) abort
     call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
 endfunction
 
 function! s:err_cb(jobid, opts, job, data) abort
+    call a:opts.on_stderr(a:jobid, a:data, 'stderr')
+endfunction
+
+function! s:err_cb_array(jobid, opts, job, data) abort
     call a:opts.on_stderr(a:jobid, split(a:data, "\n", 1), 'stderr')
 endfunction
 
@@ -73,9 +81,19 @@ function! s:on_stdout(jobid, data, event) abort
     call l:jobinfo.opts.on_stdout(a:jobid, a:data, a:event)
 endfunction
 
+function! s:on_stdout_string(jobid, data, event) abort
+    let l:jobinfo = s:jobs[a:jobid]
+    call l:jobinfo.opts.on_stdout(a:jobid, join(a:data, "\n"), a:event)
+endfunction
+
 function! s:on_stderr(jobid, data, event) abort
     let l:jobinfo = s:jobs[a:jobid]
     call l:jobinfo.opts.on_stderr(a:jobid, a:data, a:event)
+endfunction
+
+function! s:on_stderr_string(jobid, data, event) abort
+    let l:jobinfo = s:jobs[a:jobid]
+    call l:jobinfo.opts.on_stderr(a:jobid, join(a:data, "\n"), a:event)
 endfunction
 
 function! s:on_exit(jobid, status, event) abort
@@ -124,12 +142,17 @@ function! s:job_start(cmd, opts) abort
       let l:jobopt.cwd = a:opts.cwd 
     endif
 
+    let l:normalize = get(a:opts, 'normalize', 'array') " array/string/raw
+
     if l:jobtype == s:job_type_nvimjob
-        call extend(l:jobopt, {
-            \ 'on_stdout': has_key(a:opts, 'on_stdout') ? function('s:on_stdout') : function('s:noop'),
-            \ 'on_stderr': has_key(a:opts, 'on_stderr') ? function('s:on_stderr') : function('s:noop'),
-            \ 'on_exit': function('s:on_exit'),
-        \})
+        if l:normalize ==# 'string'
+            let l:jobopt['on_stdout'] = has_key(a:opts, 'on_stdout') ? function('s:on_stdout_string') : function('s:noop')
+            let l:jobopt['on_stderr'] = has_key(a:opts, 'on_stderr') ? function('s:on_stderr_string') : function('s:noop')
+        else " array or raw
+            let l:jobopt['on_stdout'] = has_key(a:opts, 'on_stdout') ? function('s:on_stdout') : function('s:noop')
+            let l:jobopt['on_stderr'] = has_key(a:opts, 'on_stderr') ? function('s:on_stderr') : function('s:noop')
+        endif
+        call extend(l:jobopt, { 'on_exit': function('s:on_exit') })
         let l:job = jobstart(a:cmd, l:jobopt)
         if l:job <= 0
             return l:job
@@ -143,9 +166,14 @@ function! s:job_start(cmd, opts) abort
     elseif l:jobtype == s:job_type_vimjob
         let s:jobidseq = s:jobidseq + 1
         let l:jobid = s:jobidseq
+        if l:normalize ==# 'array'
+            let l:jobopt['out_cb'] = has_key(a:opts, 'on_stdout') ? function('s:out_cb_array', [l:jobid, a:opts]) : function('s:noop')
+            let l:jobopt['err_cb'] = has_key(a:opts, 'on_stderr') ? function('s:err_cb_array', [l:jobid, a:opts]) : function('s:noop')
+        else " raw or string
+            let l:jobopt['out_cb'] = has_key(a:opts, 'on_stdout') ? function('s:out_cb', [l:jobid, a:opts]) : function('s:noop')
+            let l:jobopt['err_cb'] = has_key(a:opts, 'on_stderr') ? function('s:err_cb', [l:jobid, a:opts]) : function('s:noop')
+        endif
         call extend(l:jobopt, {
-            \ 'out_cb': has_key(a:opts, 'on_stdout') ? function('s:out_cb', [l:jobid, a:opts]) : function('s:noop'),
-            \ 'err_cb': has_key(a:opts, 'on_stderr') ? function('s:err_cb', [l:jobid, a:opts]) : function('s:noop'),
             \ 'exit_cb': function('s:exit_cb', [l:jobid, a:opts]),
             \ 'mode': 'raw',
         \ })
@@ -300,6 +328,12 @@ endfunction
 
 function! s:callback_cb(jobid, opts, ch, data) abort
     if has_key(a:opts, 'on_stdout')
+        call a:opts.on_stdout(a:jobid, a:data, 'stdout')
+    endif
+endfunction
+
+function! s:callback_cb_array(jobid, opts, ch, data) abort
+    if has_key(a:opts, 'on_stdout')
         call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
     endif
 endfunction
@@ -340,10 +374,11 @@ function! async#job#connect(addr, opts) abort
     let s:jobidseq = s:jobidseq + 1
     let l:jobid = s:jobidseq
     let l:retry = 0
+    let l:normalize = get(a:opts, 'normalize', 'array') " array/string/raw
     while l:retry < 5
         let l:ch = ch_open(a:addr, {'waittime': 1000})
         call ch_setoptions(l:ch, {
-            \ 'callback': function('s:callback_cb', [l:jobid, a:opts]),
+            \ 'callback': function(l:normalize ==# 'array' ? 's:callback_cb_array' : 's:callback_cb', [l:jobid, a:opts]),
             \ 'close_cb': function('s:close_cb', [l:jobid, a:opts]),
             \ 'mode': 'raw',
         \})


### PR DESCRIPTION
One of the big mistakes I did in designing async.vim was to default to neovim output. Most of the time you need to get string and this can be costly for vim, since vim by default returns a string, which means we call split in async.vim then the consumer calls join which should had ideally been a noop. This allocates unnecessary memory due to string and array creation. Luckily we can have 100% backwards compatibility as I still default to 'array' if not passed and one can easily override it to 'string'. For callbag.vim's `spawn` function I had defaulted to 'raw' and make the user decide if they want compatibility.